### PR TITLE
Re-add accidentally removed .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /node_modules
 .env
-.dockerignore


### PR DESCRIPTION
Building without the .dockerignore can cause the container to attempt to use the host system binaries instead of the container binaries. Re-adding the accidentally removed .dockerignore fixes this issue.