### PR TITLE
deleting package-lock.json as part of build to avoid npm errors

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,6 +1,5 @@
 FROM node:10
 WORKDIR /app
 COPY . /app
-RUN npm install
-RUN npm install -g nodemon
+RUN rm package-lock.json && npm install && npm install -g nodemon
 CMD [ "npm", "run", "devstart" ]


### PR DESCRIPTION
Not sure why the package-lock file is causing problems, some info online suggests its a bug with npm and switching to yarn fixes it... For this project. I'd rather not mess with making that change. Deleting the file before running npm install will work and get us through the rest of this week.